### PR TITLE
Allow clicking on wizard steps to navigate back 

### DIFF
--- a/src/form/form-wizard/form-wizard.component.html
+++ b/src/form/form-wizard/form-wizard.component.html
@@ -1,6 +1,8 @@
 <bal-wizard-overview
   [steps]="steps"
   [activeStep]="activeStep"
+  [disableStepsAfterActiveStep]="disableStepsAfterActiveStep"
+  (clickOnStep)="onClickOnStep($event)"
   *ngIf="shouldShowStepOverview()"
 >
 </bal-wizard-overview>

--- a/src/form/form-wizard/form-wizard.component.ts
+++ b/src/form/form-wizard/form-wizard.component.ts
@@ -41,6 +41,8 @@ export class FormWizardComponent
       save: string;
     };
   };
+  @Input() disableStepsAfterActiveStep = false;
+  @Input() enableDirectNavigationBackward = false;
 
   @Output() beforeNavigateForward = new EventEmitter<WizardStep>();
   @Output() navigateForward = new EventEmitter<WizardStep>();
@@ -271,5 +273,14 @@ export class FormWizardComponent
   private getActiveStepIndex(): number {
     const index = this.steps.indexOf(this.activeStep);
     return index >= 0 ? index : 0;
+  }
+
+  onClickOnStep(clickedStep: WizardStep): void {
+    if (!this.enableDirectNavigationBackward || this.steps.indexOf(clickedStep) > this.steps.indexOf(this.activeStep)) {
+      return;
+    }
+    // enable direct backward navigation
+    this.activeStep = clickedStep;
+    this.showActiveStepComponent();
   }
 }

--- a/src/form/form-wizard/wizard-overview/wizard-overview.component.html
+++ b/src/form/form-wizard/wizard-overview/wizard-overview.component.html
@@ -5,7 +5,8 @@
     (click)="clickOnStep.emit(step)"
     [ngClass]="{
       active: isActive(step),
-      clickable: thereIsSubscriptionOnStepClick
+      clickable: thereIsSubscriptionOnStepClick,
+      disabled: shouldMarkAsDisabled(step)
     }"
   >
     <div class="done" *ngIf="isDone(step)">

--- a/src/form/form-wizard/wizard-overview/wizard-overview.component.scss
+++ b/src/form/form-wizard/wizard-overview/wizard-overview.component.scss
@@ -62,6 +62,16 @@
       font-size: $size-7;
       color: $blue;
     }
+    &.disabled {
+      h5 {
+        color: $text-light;
+      }
+
+      &.step .circle {
+        border: solid $text-light 1px;
+        color: $text-light;
+      }
+    }
     &.active {
       border-bottom: solid $blue-light-hover 2px;
     }

--- a/src/form/form-wizard/wizard-overview/wizard-overview.component.ts
+++ b/src/form/form-wizard/wizard-overview/wizard-overview.component.ts
@@ -9,6 +9,7 @@ import { WizardStep } from "../models";
 export class WizardOverviewComponent implements OnInit {
   @Input() activeStep: WizardStep;
   @Input() steps: WizardStep[] = [];
+  @Input() disableStepsAfterActiveStep = false;
 
   @Output() clickOnStep: EventEmitter<WizardStep> =
     new EventEmitter<WizardStep>();
@@ -32,5 +33,9 @@ export class WizardOverviewComponent implements OnInit {
 
   isActive(step: WizardStep): boolean {
     return this.steps.indexOf(step) === this.steps.indexOf(this.activeStep);
+  }
+
+  shouldMarkAsDisabled(step: WizardStep): boolean {
+    return this.disableStepsAfterActiveStep && this.steps.indexOf(step) > this.steps.indexOf(this.activeStep);
   }
 }


### PR DESCRIPTION
Added two new input params to form-wizard, both are 'false' by default:
- enableDirectNavigationBackward  - adds possibility to navigate back in wizard by clicking directly on WizardStep
- disableStepsAfterActiveStep  - adds 'disabled' class to steps after active step